### PR TITLE
Add validation to UpdateConfig

### DIFF
--- a/invalid_json.json
+++ b/invalid_json.json
@@ -1,0 +1,1 @@
+{"test_bool":false,"test_int":5,"test_string":"zaphod", "test_string_slice": [ "foo", "bar", "quux" ], }


### PR DESCRIPTION
Previously, invalid json would be accepted and used.

Now, when an attempt to update the config is made, an error is returned.